### PR TITLE
doc: use cmake --build

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,8 @@ To install them, build llvm with clang-tools-extra enabled, and:
 `make install-llvm-headers install-clang-tidy-headers install-clang-headers`
 
 ### Building the plugin:
-- mkdir build
-- cd build
-- cmake ..
-- make
+- cmake -S . -B build
+- cmake --build build
 
 ### Using the plugin:
 


### PR DESCRIPTION
We can save some directory hopping and suggest more "modern" commands for anyone using CMake 3.13+ (likely everywhere this repo would be built). Anyone using an older CMake can still use different commands.

I'm using this in my integration branch, here: https://github.com/fanquake/bitcoin/commit/f8c8be3e9cd9dfd27974751404f341ecee7c4e30#diff-4e4af46a1ce34a4dd31f9da0da8686e40c20e8113ba72c7c7015c00100caf5e8R130-R135.

Example output:
```bash
Cloning into '/home/ubuntu/ci_scratch/ci/scratch/bitcoin-tidy'...
-- The C compiler identification is GNU 11.2.0
-- The CXX compiler identification is GNU 11.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done
-- Generating done
-- Build files have been written to: /home/ubuntu/ci_scratch/ci/scratch/bitcoin-tidy/build
[ 33%] Building CXX object CMakeFiles/bitcoin-tidy.dir/bitcoin-tidy.cpp.o
[ 66%] Building CXX object CMakeFiles/bitcoin-tidy.dir/desig_init.cpp.o
[100%] Linking CXX shared library libbitcoin-tidy.so
[100%] Built target bitcoin-tidy
```